### PR TITLE
Add sysv init support for RHEL <7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,8 @@ autossh_default_server_key_type: "ecdsa"
 
 autossh_default_dest_server: "127.0.0.1"
 
+autossh_default_bind_address: "127.0.0.1"
+
 autossh_default_identity_file: "/root/.ssh/id_rsa"
 
 autossh_connections:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,8 @@ galaxy_info:
   platforms:
   - name: EL
     versions:
+    - 5
+    - 6
     - 7
   galaxy_tags:
     - autossh

--- a/tasks/common-RedHat.yml
+++ b/tasks/common-RedHat.yml
@@ -1,0 +1,14 @@
+---
+- name: Install autossh.
+  package: name=autossh enablerepo=epel state=latest
+
+- name: Ensure ssh directory exists.
+  file: path="{{ autossh_ssh_dir }}" state=directory mode=0700
+
+- name: Ensure known hosts file exists.
+  copy: content="" dest={{ autossh_known_hosts_file }} force=no
+
+- name: Scan for public key of destination server.
+  shell: ssh-keyscan -t {{ item.server_key_type | default(autossh_default_server_key_type) }} {{ item.server }} >> {{ autossh_known_hosts_file }}
+  changed_when: false
+  with_items: "{{ autossh_connections }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,9 @@
 ---
-- include: tasks/systemd-RedHat.yml
+- include: common-RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: systemd-RedHat.yml
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version | int == 7
+
+- include: sysvinit-RedHat.yml
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version | int < 7

--- a/tasks/systemd-RedHat.yml
+++ b/tasks/systemd-RedHat.yml
@@ -1,18 +1,4 @@
 ---
-- name: Install autossh.
-  package: name=autossh state=latest
-
-- name: Ensure ssh directory exists.
-  file: path="{{ autossh_ssh_dir }}" state=directory mode=0700
-
-- name: Ensure known hosts file exists.
-  copy: content="" dest={{ autossh_known_hosts_file }} force=no
-
-- name: Scan for public key of destination server.
-  shell: ssh-keyscan -t {{ item.server_key_type | default(autossh_default_server_key_type) }} {{ item.server }} >> {{ autossh_known_hosts_file }}
-  changed_when: false
-  with_items: "{{ autossh_connections }}"
-
 - name: Copy autossh services to systemd.
   template:
     src: templates/autossh.service.j2

--- a/tasks/sysvinit-RedHat.yml
+++ b/tasks/sysvinit-RedHat.yml
@@ -1,0 +1,12 @@
+---
+- name: Copy autossh services to init.d.
+  template:
+    src: templates/autossh.sysvinit.j2
+    dest: "/etc/init.d/autossh-{{ item.id | lower | regex_replace('\\s+', '-') | regex_replace('[^a-z0-9-]', '') }}"
+    mode: 0755
+  with_items: "{{ autossh_connections }}"
+  register: autossh_sysvinit_service
+
+- name: set INIT status
+  service: name="autossh-{{ item.id | lower | regex_replace('\\s+', '-') | regex_replace('[^a-z0-9-]', '') }}" enabled=yes
+  with_items: "{{ autossh_connections }}"

--- a/templates/autossh.service.j2
+++ b/templates/autossh.service.j2
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 ExecStart={{ autossh_path }} -M 0 -N -q -o "ServerAliveInterval 60" -o "ServerAliveCountMax 3" \
--L {{ item.local_port }}:{{ item.dest_server | default(autossh_default_dest_server) }}:{{ item.dest_port }} \
+-L {{ item.bind_address | default(autossh_default_bind_address) }}:{{ item.local_port }}:{{ item.dest_server | default(autossh_default_dest_server) }}:{{ item.dest_port }} \
 -i {{ item.identity_file | default(autossh_default_identity_file) }} \
 {{ item.user }}@{{ item.server }}
 Restart=always

--- a/templates/autossh.sysvinit.j2
+++ b/templates/autossh.sysvinit.j2
@@ -1,0 +1,81 @@
+#!/bin/sh
+#
+# /etc/init.d/mysystem
+# Subsystem file for "MySystem" server
+#
+# chkconfig: 2345 95 05
+# description: AutoSSH service for {{ item.id }} to tunnel port {{ item.local_port }} to {{ item.dest_port }} on {{ item.server }}
+#
+# processname: autossh
+# config: /etc/sysconfig/autossh
+# source function library
+. /etc/rc.d/init.d/functions
+
+# pull in sysconfig settings
+[ -f /etc/sysconfig/autossh ] && . /etc/sysconfig/autossh
+
+RETVAL=0
+prog="autossh-{{ item.id | lower | regex_replace('\\s+', '-') | regex_replace('[^a-z0-9-]', '') }}"
+PIDFILE="/var/run/${prog}.pid"
+
+start() {
+        echo -n $"Starting $prog: "
+        export AUTOSSH_PIDFILE="$PIDFILE"
+	daemon --pidfile="$PIDFILE" {{ autossh_path }} \
+             -f -M 0 -N -v -o "\"ServerAliveInterval 60\"" -o "\"ServerAliveCountMax 3\"" \
+             -L {{ item.bind_address | default(autossh_default_bind_address) }}:{{ item.local_port }}:{{ item.dest_server | default(autossh_default_dest_server) }}:{{ item.dest_port }} \
+             -i {{ item.identity_file | default(autossh_default_identity_file) }} \
+             {{ item.user }}@{{ item.server }}
+	RETVAL=$?
+	[ "$RETVAL" = 0 ] && touch /var/lock/subsys/$prog
+	echo
+        return $RETVAL
+}
+
+stop() {
+	echo -n $"Stopping $prog: "
+	killproc -p "$PIDFILE" $exec
+	RETVAL=$?
+	[ "$RETVAL" = 0 ] && rm -f /var/lock/subsys/$prog
+	echo
+        return $RETVAL
+}
+
+reload() {
+	echo -n $"Reloading $prog:"
+	killproc $prog -HUP
+	RETVAL=$?
+	echo
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	restart)
+		stop
+		start
+		;;
+	reload)
+		reload
+		;;
+	condrestart)
+		if [ -f /var/lock/subsys/$prog ] ; then
+			stop
+			# avoid race
+			sleep 3
+			start
+		fi
+		;;
+	status)
+		status $prog
+		RETVAL=$?
+		;;
+	*)
+		echo $"Usage: $0 {start|stop|restart|reload|condrestart|status}"
+		RETVAL=1
+esac
+exit $RETVAL


### PR DESCRIPTION
Hi!  Thanks for providing your Ansible module--it was very helpful!

I'm using Amazon Linux, which RHEL 5/6-derived and thus uses sysvinit, so I added an rc.d script to start the service and broke out the common Red Hat bits.

I also needed to use the bind address configuration, so I provided a new default (matching ssh's default) which can be overridden.

Let me know if you have any thoughts on the patch!
