### PR TITLE
only import epel role for RedHat

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,4 +16,5 @@ galaxy_info:
     - ssh
     - tunnel
 dependencies:
-    - geerlingguy.repo-epel
+    - role: geerlingguy.repo-epel
+      when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
We are wrapping this role to add debian functionality, but this breaks on the dependency for the EPEL role. This commit makes the dependency limited to RedHat systems.

Note that I could merge the Debian functionality from the wrapper role into this role and do a PR for that too, if deemed useful.